### PR TITLE
Entity update: add duck.ai to DuckDuckGo entity

### DIFF
--- a/build-data/generated/domain_map.json
+++ b/build-data/generated/domain_map.json
@@ -90093,6 +90093,14 @@
         ],
         "displayName": "Duck Duck Go"
     },
+    "duck.ai": {
+        "entityName": "Duck Duck Go, Inc.",
+        "aliases": [
+            "Duck Duck Go, Inc.",
+            "DuckDuckGo"
+        ],
+        "displayName": "Duck Duck Go"
+    },
     "duck.co": {
         "entityName": "Duck Duck Go, Inc.",
         "aliases": [

--- a/build-data/generated/entity_map.json
+++ b/build-data/generated/entity_map.json
@@ -47816,6 +47816,7 @@
             "dgg.gg",
             "dontbubble.us",
             "donttrack.us",
+            "duck.ai",
             "duck.co",
             "duck.com",
             "duckduckapi.com",

--- a/entities/Duck Duck Go, Inc..json
+++ b/entities/Duck Duck Go, Inc..json
@@ -13,6 +13,7 @@
         "dgg.gg",
         "dontbubble.us",
         "donttrack.us",
+        "duck.ai",
         "duck.co",
         "duck.com",
         "duckduckapi.com",


### PR DESCRIPTION
Adding duck.ai domain to DuckDuckGo entity data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only entity/domain mapping with no runtime logic changes; mis-attribution risk is limited to blocking or labeling for one new domain.
> 
> **Overview**
> Adds **`duck.ai`** to the Duck Duck Go entity so the domain is attributed to Duck Duck Go, Inc. alongside existing DuckDuckGo properties.
> 
> The change updates the source entity file and the generated **`domain_map`** and **`entity_map`** build data so lookups for `duck.ai` resolve to the same entity aliases and display name as other DuckDuckGo domains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0e458f0904043b8a65fe3862a93409dd1a8c31a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->